### PR TITLE
fix #46 goig back to facebook omoniauth for sign in

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,33 +1,33 @@
 module SessionsHelper
-  # def sign_in(user)
-  #   remember_token = User.new_remember_token
-  #   cookies.permanent[:remember_token] = remember_token
-  #   user.update_attribute(:remember_token, User.digest(remember_token))
-  #   self.current_user = user
-  # end
+  def sign_in(user)
+    remember_token = User.new_remember_token
+    cookies.permanent[:remember_token] = remember_token
+    user.update_attribute(:remember_token, User.digest(remember_token))
+    self.current_user = user
+  end
 
-  # def signed_in?
-  #   !current_user.nil?
-  # end
+  def signed_in?
+    !current_user.nil?
+  end
 
-  # def current_user=(user)
-  #   @current_user = user
-  # end
+  def current_user=(user)
+    @current_user = user
+  end
 
-  # def current_user
-  #   remember_token = User.digest(cookies[:remember_token])
-  #   @current_user ||= User.find_by(remember_token: remember_token)
-  # end
+  def current_user
+    remember_token = User.digest(cookies[:remember_token])
+    @current_user ||= User.find_by(remember_token: remember_token)
+  end
 
-  # def current_user?(user)
-  #   user == current_user
-  # end
+  def current_user?(user)
+    user == current_user
+  end
 
-  # def sign_out
-  #   if current_user
-  #     current_user.update_attribute(:remember_token, User.digest(User.new_remember_token))
-  #     cookies.delete(:remember_token)
-  #     current_user = nil
-  #   end
-  # end
+  def sign_out
+    if current_user
+      current_user.update_attribute(:remember_token, User.digest(User.new_remember_token))
+      cookies.delete(:remember_token)
+      current_user = nil
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable, :rememberable, :recoverable, :validatable, :omniauthable #,  :confirmable
+  # devise :database_authenticatable, :registerable, :rememberable, :recoverable, :validatable, :omniauthable #,  :confirmable
   rolify
   before_save { email.downcase! }
   before_create :create_remember_token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 RailsMakeupScheduler::Application.routes.draw do
-  devise_for :users
+  # devise_for :users
   root 'static_pages#home'
   match '/help',   to: 'static_pages#help',   via: 'get'
   match '/contact',  to: 'static_pages#contact',  via: 'get'

--- a/db/migrate/20150329163725_remove_colum_from_user.rb
+++ b/db/migrate/20150329163725_remove_colum_from_user.rb
@@ -1,0 +1,36 @@
+class RemoveColumFromUser < ActiveRecord::Migration
+  def up
+    remove_index :users, :reset_password_token
+    remove_index :users, :confirmation_token
+
+    remove_column :users, :reset_password_token, :string
+    remove_column :users, :reset_password_token, :string
+    remove_column :users, :reset_password_sent_at, :datetime
+    remove_column :users, :remember_created_at, :datetime
+    remove_column :users, :sign_in_count, :integer
+    remove_column :users, :current_sign_in_at, :datetime
+    remove_column :users, :last_sign_in_at, :datetime
+    remove_column :users, :current_sign_in_ip, :string
+    remove_column :users, :last_sign_in_ip, :string
+    remove_column :users, :confirmation_token, :string
+    remove_column :users, :confirmed_at, :datetime
+    remove_column :users, :confirmation_sent_at, :datetime
+  end
+
+  def down
+    add_column :users, :reset_password_token,   :string
+    add_column :users, :reset_password_sent_at, :datetime
+    add_column :users, :remember_created_at,    :datetime
+    add_column :users, :sign_in_count,          :integer, default: 0, null: false
+    add_column :users, :current_sign_in_at,     :datetime
+    add_column :users, :last_sign_in_at,        :datetime
+    add_column :users, :current_sign_in_ip,     :string
+    add_column :users, :last_sign_in_ip,        :string
+    add_column :users, :confirmation_token,     :string
+    add_column :users, :confirmed_at,           :datetime
+    add_column :users, :confirmation_sent_at,   :datetime
+
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150321194628) do
+ActiveRecord::Schema.define(version: 20150329163725) do
 
   create_table "businesses", force: true do |t|
     t.string   "name"
@@ -50,30 +50,17 @@ ActiveRecord::Schema.define(version: 20150321194628) do
 
   create_table "users", force: true do |t|
     t.string   "name"
-    t.string   "email",                  default: "", null: false
+    t.string   "email",              default: "", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "remember_token"
     t.string   "provider"
     t.string   "uid"
     t.integer  "business_id"
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.string   "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
+    t.string   "encrypted_password", default: "", null: false
   end
 
-  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
   add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
   create_table "users_roles", id: false, force: true do |t|
     t.integer "user_id"


### PR DESCRIPTION
- Commented out `Devise` methods in routes and models.  
- Uncommented previous `SessionHelpers` to override `Devise` session helpers.
- Deleted user fields from database needed for devise strategies (`user.encrypted_password`) still there
